### PR TITLE
Fix CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,4 @@ addons:
   sauce_connect: true
 script:
   - xvfb-run wct
-  - "if [ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ]; then wct -s 'default'; fi"
 dist: trusty

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Polymer element for the [plotly.js](https://plot.ly/javascript/) library.
 
+[![Build Status](https://travis-ci.org/ginkgobioworks/plotly-plot.svg?branch=master)](https://travis-ci.org/ginkgobioworks/plotly-plot)
+
 `<plotly-plot>` provides a thin, fully-functional interface to the core of the
 library. The key properties of the plot, `data`, `layout`, and `config`, are
 all exposed as Polymer properties; updates to these properties via `.set` will

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "SEE LICENSE IN http://polymer.github.io/LICENSE.txt",
   "homepage": "https://ginkgobioworks.github.io/plotly-plot/",
   "dependencies": {
-    "Polymer": "^1.2.0",
-    "plotly.js": "^1.10.2"
+    "plotly.js": "^1.10.2",
+    "Polymer": "^1.6.0"
   },
   "files": [
     "index.html",
@@ -42,7 +42,7 @@
     "web-component-tester": "^4.0.0"
   },
   "peerDependencies": {
-    "Polymer": "^1.2.0"
+    "Polymer": "^1.6.0"
   },
   "scripts": {
     "start": "polyserve",


### PR DESCRIPTION
Even though the Polymer boilerplate came with a `.travis.yml` file for easy CI integration, it did not work right off the bat. Minor fixes necessary to make it work right.